### PR TITLE
Script: Move Map impl from IngestSourceAndMetadata to CtxMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestCtxMap.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestCtxMap.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.ingest;
+
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.script.CtxMap;
+import org.elasticsearch.script.Metadata;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Map containing ingest source and metadata.
+ *
+ * The Metadata values in {@link IngestDocument.Metadata} are validated when put in the map.
+ * _index, _id and _routing must be a String or null
+ * _version_type must be a lower case VersionType or null
+ * _version must be representable as a long without loss of precision or null
+ * _dyanmic_templates must be a map
+ * _if_seq_no must be a long or null
+ * _if_primary_term must be a long or null
+ *
+ * The map is expected to be used by processors, server code should the typed getter and setters where possible.
+ */
+class IngestCtxMap extends CtxMap {
+
+    /**
+     * Create an IngestCtxMap with the given metadata, source and default validators
+     */
+    IngestCtxMap(
+        String index,
+        String id,
+        long version,
+        String routing,
+        VersionType versionType,
+        ZonedDateTime timestamp,
+        Map<String, Object> source
+    ) {
+        super(new HashMap<>(source), new Metadata(index, id, version, routing, versionType, timestamp));
+    }
+
+    /**
+     * Create IngestCtxMap from a source and metadata
+     *
+     * @param source the source document map
+     * @param metadata the metadata map
+     */
+    IngestCtxMap(Map<String, Object> source, Metadata metadata) {
+        super(source, metadata);
+    }
+
+    /**
+     * Returns a new metadata map and the existing source map with metadata removed.
+     */
+    public static Tuple<Map<String, Object>, Map<String, Object>> splitSourceAndMetadata(Map<String, Object> sourceAndMetadata) {
+        return CtxMap.splitSourceAndMetadata(
+            sourceAndMetadata,
+            Arrays.stream(IngestDocument.Metadata.values()).map(IngestDocument.Metadata::getFieldName).collect(Collectors.toSet())
+        );
+    }
+
+    /**
+     * Fetch the timestamp from the ingestMetadata, if it exists
+     * @return the timestamp for the document or null
+     */
+    public static ZonedDateTime getTimestamp(Map<String, Object> ingestMetadata) {
+        if (ingestMetadata == null) {
+            return null;
+        }
+        Object ts = ingestMetadata.get(IngestDocument.TIMESTAMP);
+        if (ts instanceof ZonedDateTime timestamp) {
+            return timestamp;
+        } else if (ts instanceof String str) {
+            return ZonedDateTime.parse(str);
+        }
+        return null;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -2228,7 +2228,7 @@ public class IngestServiceTests extends ESTestCase {
 
         @Override
         public boolean matches(IngestDocument other) {
-            // ingest metadata and IngestSourceAndMetadata will not be the same (timestamp differs every time)
+            // ingest metadata and IngestCtxMap will not be the same (timestamp differs every time)
             return Objects.equals(ingestDocument.getSource(), other.getSource())
                 && Objects.equals(ingestDocument.getMetadata().getMap(), other.getMetadata().getMap());
         }

--- a/test/framework/src/main/java/org/elasticsearch/ingest/TestIngestDocument.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/TestIngestDocument.java
@@ -37,8 +37,8 @@ public class TestIngestDocument {
      * _versions.  Normally null _version is not allowed, but many tests don't care about that invariant.
      */
     public static IngestDocument ofIngestWithNullableVersion(Map<String, Object> sourceAndMetadata, Map<String, Object> ingestMetadata) {
-        Tuple<Map<String, Object>, Map<String, Object>> sm = IngestSourceAndMetadata.splitSourceAndMetadata(sourceAndMetadata);
-        return new IngestDocument(new IngestSourceAndMetadata(sm.v1(), TestMetadata.withNullableVersion(sm.v2())), ingestMetadata);
+        Tuple<Map<String, Object>, Map<String, Object>> sm = IngestCtxMap.splitSourceAndMetadata(sourceAndMetadata);
+        return new IngestDocument(new IngestCtxMap(sm.v1(), TestMetadata.withNullableVersion(sm.v2())), ingestMetadata);
     }
 
     /**
@@ -57,7 +57,7 @@ public class TestIngestDocument {
      * can observe changes to the map directly.
      */
     public static IngestDocument ofMetadataWithValidator(Map<String, Object> metadata, Map<String, Metadata.Validator> validators) {
-        return new IngestDocument(new IngestSourceAndMetadata(new HashMap<>(), new TestMetadata(metadata, validators)), new HashMap<>());
+        return new IngestDocument(new IngestCtxMap(new HashMap<>(), new TestMetadata(metadata, validators)), new HashMap<>());
     }
 
     /**


### PR DESCRIPTION
Move the Map implementation from `ingest.IngestSourceAndMetadata` to `script.CtxMap`.